### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-##IMPORTANT NOTICE
+## IMPORTANT NOTICE
 This project is no longer maintained. To achieve the same effect, please see: https://github.com/datwelk/RDRGrowingTextView.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
